### PR TITLE
Add batch encode/decode endpoints with validation

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,26 +1,37 @@
-const express = require('express');
-const cors = require('cors');
-const morgan = require('morgan');
-const digipinRoutes = require('./routes/digipin.routes');
-const swaggerUi = require('swagger-ui-express');
-const YAML = require('yaml');
-const fs = require('fs');
-const path = require('path');
+const express = require("express");
+const cors = require("cors");
+const morgan = require("morgan");
+const digipinRoutes = require("./routes/digipin.routes");
+const swaggerUi = require("swagger-ui-express");
+const YAML = require("yaml");
+const fs = require("fs");
+const path = require("path");
 
 // const swaggerDocument = YAML.load(path.join(__dirname, '../swagger.yaml'));
-const swaggerDocument = YAML.parse(fs.readFileSync(path.join(__dirname, '../swagger.yaml'), 'utf8'));
+const swaggerDocument = YAML.parse(
+  fs.readFileSync(path.join(__dirname, "../swagger.yaml"), "utf8"),
+);
 
 const app = express();
 
 // Middleware
 app.use(cors());
 app.use(express.json());
-app.use(morgan('dev'));
+app.use(morgan("dev"));
+
+// Catch JSON parsing errors
+app.use((err, req, res, next) => {
+  if (err instanceof SyntaxError && err.status === 400 && 'body' in err) {
+    return res.status(400).json({ error: "Invalid JSON format" });
+  }
+  next();
+});
+
 
 // Swagger Docs Route
-app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
+app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 // DIGIPIN API Routes
-app.use('/api/digipin', digipinRoutes);
+app.use("/api/digipin", digipinRoutes);
 
 module.exports = app;

--- a/src/digipin.js
+++ b/src/digipin.js
@@ -9,109 +9,111 @@
  */
 
 const DIGIPIN_GRID = [
-    ['F', 'C', '9', '8'],
-    ['J', '3', '2', '7'],
-    ['K', '4', '5', '6'],
-    ['L', 'M', 'P', 'T']
-  ];
-  
-  const BOUNDS = {
-    minLat: 2.5,
-    maxLat: 38.5,
-    minLon: 63.5,
-    maxLon: 99.5
-  };
-  
-  function getDigiPin(lat, lon) {
-    if (lat < BOUNDS.minLat || lat > BOUNDS.maxLat) throw new Error('Latitude out of range');
-    if (lon < BOUNDS.minLon || lon > BOUNDS.maxLon) throw new Error('Longitude out of range');
-  
-    let minLat = BOUNDS.minLat;
-    let maxLat = BOUNDS.maxLat;
-    let minLon = BOUNDS.minLon;
-    let maxLon = BOUNDS.maxLon;
-  
-    let digiPin = '';
-  
-    for (let level = 1; level <= 10; level++) {
-      const latDiv = (maxLat - minLat) / 4;
-      const lonDiv = (maxLon - minLon) / 4;
-  
-      // REVERSED row logic (to match original)
-      let row = 3 - Math.floor((lat - minLat) / latDiv);
-      let col = Math.floor((lon - minLon) / lonDiv);
-  
-      row = Math.max(0, Math.min(row, 3));
-      col = Math.max(0, Math.min(col, 3));
-  
-      digiPin += DIGIPIN_GRID[row][col];
-  
-      if (level === 3 || level === 6) digiPin += '-';
-  
-      // Update bounds (reverse logic for row)
-      maxLat = minLat + latDiv * (4 - row);
-      minLat = minLat + latDiv * (3 - row);
-  
-      minLon = minLon + lonDiv * col;
-      maxLon = minLon + lonDiv;
-    }
-  
-    return digiPin;
+  ["F", "C", "9", "8"],
+  ["J", "3", "2", "7"],
+  ["K", "4", "5", "6"],
+  ["L", "M", "P", "T"],
+];
+
+const BOUNDS = {
+  minLat: 2.5,
+  maxLat: 38.5,
+  minLon: 63.5,
+  maxLon: 99.5,
+};
+
+function getDigiPin(lat, lon) {
+  if (lat < BOUNDS.minLat || lat > BOUNDS.maxLat)
+    throw new Error("Latitude out of range");
+  if (lon < BOUNDS.minLon || lon > BOUNDS.maxLon)
+    throw new Error("Longitude out of range");
+
+  let minLat = BOUNDS.minLat;
+  let maxLat = BOUNDS.maxLat;
+  let minLon = BOUNDS.minLon;
+  let maxLon = BOUNDS.maxLon;
+
+  let digiPin = "";
+
+  for (let level = 1; level <= 10; level++) {
+    const latDiv = (maxLat - minLat) / 4;
+    const lonDiv = (maxLon - minLon) / 4;
+
+    // REVERSED row logic (to match original)
+    let row = 3 - Math.floor((lat - minLat) / latDiv);
+    let col = Math.floor((lon - minLon) / lonDiv);
+
+    row = Math.max(0, Math.min(row, 3));
+    col = Math.max(0, Math.min(col, 3));
+
+    digiPin += DIGIPIN_GRID[row][col];
+
+    if (level === 3 || level === 6) digiPin += "-";
+
+    // Update bounds (reverse logic for row)
+    maxLat = minLat + latDiv * (4 - row);
+    minLat = minLat + latDiv * (3 - row);
+
+    minLon = minLon + lonDiv * col;
+    maxLon = minLon + lonDiv;
   }
-  
-  
-  function getLatLngFromDigiPin(digiPin) {
-    const pin = digiPin.replace(/-/g, '');
-    if (pin.length !== 10) throw new Error('Invalid DIGIPIN');
-    
-    let minLat = BOUNDS.minLat;
-    let maxLat = BOUNDS.maxLat;
-    let minLon = BOUNDS.minLon;
-    let maxLon = BOUNDS.maxLon;
-  
-    for (let i = 0; i < 10; i++) {
-      const char = pin[i];
-      let found = false;
-      let ri = -1, ci = -1;
-  
-      // Locate character in DIGIPIN grid
-      for (let r = 0; r < 4; r++) {
-        for (let c = 0; c < 4; c++) {
-          if (DIGIPIN_GRID[r][c] === char) {
-            ri = r;
-            ci = c;
-            found = true;
-            break;
-          }
+
+  return digiPin;
+}
+
+function getLatLngFromDigiPin(digiPin) {
+  const pin = digiPin.replace(/-/g, "");
+  if (pin.length !== 10) throw new Error("Invalid DIGIPIN");
+
+  let minLat = BOUNDS.minLat;
+  let maxLat = BOUNDS.maxLat;
+  let minLon = BOUNDS.minLon;
+  let maxLon = BOUNDS.maxLon;
+
+  for (let i = 0; i < 10; i++) {
+    const char = pin[i];
+    let found = false;
+    let ri = -1,
+      ci = -1;
+
+    // Locate character in DIGIPIN grid
+    for (let r = 0; r < 4; r++) {
+      for (let c = 0; c < 4; c++) {
+        if (DIGIPIN_GRID[r][c] === char) {
+          ri = r;
+          ci = c;
+          found = true;
+          break;
         }
-        if (found) break;
       }
-  
-      if (!found) throw new Error('Invalid character in DIGIPIN');
-  
-      const latDiv = (maxLat - minLat) / 4;
-      const lonDiv = (maxLon - minLon) / 4;
-  
-      const lat1 = maxLat - latDiv * (ri + 1);
-      const lat2 = maxLat - latDiv * ri;
-      const lon1 = minLon + lonDiv * ci;
-      const lon2 = minLon + lonDiv * (ci + 1);
-  
-      // Update bounding box for next level
-      minLat = lat1;
-      maxLat = lat2;
-      minLon = lon1;
-      maxLon = lon2;
+      if (found) break;
     }
-  
-    const centerLat = (minLat + maxLat) / 2;
-    const centerLon = (minLon + maxLon) / 2;
-  
-    return {
-      latitude: centerLat.toFixed(6),
-      longitude: centerLon.toFixed(6)
-    };
+
+    if (!found) throw new Error("Invalid character in DIGIPIN");
+
+    const latDiv = (maxLat - minLat) / 4;
+    const lonDiv = (maxLon - minLon) / 4;
+
+    const lat1 = maxLat - latDiv * (ri + 1);
+    const lat2 = maxLat - latDiv * ri;
+    const lon1 = minLon + lonDiv * ci;
+    const lon2 = minLon + lonDiv * (ci + 1);
+
+    // Update bounding box for next level
+    minLat = lat1;
+    maxLat = lat2;
+    minLon = lon1;
+    maxLon = lon2;
   }
-  
-  
-  if (typeof module !== 'undefined') module.exports = { getDigiPin, getLatLngFromDigiPin };
+
+  const centerLat = (minLat + maxLat) / 2;
+  const centerLon = (minLon + maxLon) / 2;
+
+  return {
+    latitude: centerLat.toFixed(6),
+    longitude: centerLon.toFixed(6),
+  };
+}
+
+if (typeof module !== "undefined")
+  module.exports = { getDigiPin, getLatLngFromDigiPin };

--- a/src/routes/digipin.routes.js
+++ b/src/routes/digipin.routes.js
@@ -1,30 +1,99 @@
-const express = require('express');
+const express = require("express");
 const router = express.Router();
-const { getDigiPin, getLatLngFromDigiPin } = require('../digipin');
+const { getDigiPin, getLatLngFromDigiPin } = require("../digipin");
 
-router.post('/encode', (req, res) => { const { latitude, longitude } = req.body; try { const code = getDigiPin(latitude, longitude); res.json({ digipin: code }); } catch (e) { res.status(400).json({ error: e.message }); } });
+const MAX_BATCH_SIZE = 100;
 
-router.post('/decode', (req, res) => { const { digipin } = req.body; try { const coords = getLatLngFromDigiPin(digipin); res.json(coords); } catch (e) { res.status(400).json({ error: e.message }); } });
+router.post("/encode", (req, res) => {
+  const { latitude, longitude } = req.body;
+  try {
+    const code = getDigiPin(latitude, longitude);
+    res.json({ digipin: code });
+  } catch (e) {
+    res.status(400).json({ error: e.message });
+  }
+});
 
-  router.get('/encode', (req, res) => {
-    const { latitude, longitude } = req.query;
+router.post("/decode", (req, res) => {
+  const { digipin } = req.body;
+  try {
+    const coords = getLatLngFromDigiPin(digipin);
+    res.json(coords);
+  } catch (e) {
+    res.status(400).json({ error: e.message });
+  }
+});
+
+router.get("/encode", (req, res) => {
+  const { latitude, longitude } = req.query;
+  try {
+    const code = getDigiPin(parseFloat(latitude), parseFloat(longitude));
+    res.json({ digipin: code });
+  } catch (e) {
+    res.status(400).json({ error: e.message });
+  }
+});
+
+router.get("/decode", (req, res) => {
+  const { digipin } = req.query;
+  try {
+    const coords = getLatLngFromDigiPin(digipin);
+    res.json(coords);
+  } catch (e) {
+    res.status(400).json({ error: e.message });
+  }
+});
+
+// POST /encode/batch
+router.post("/encode/batch", (req, res) => {
+  const { coords } = req.body;
+
+  if (!Array.isArray(coords)) {
+    return res.status(400).json({ error: "coords must be an array" });
+  }
+
+  if (coords.length > MAX_BATCH_SIZE) {
+    return res
+      .status(413)
+      .json({ error: `Max ${MAX_BATCH_SIZE} coordinates allowed` });
+  }
+
+  const results = coords.map(({ latitude, longitude }) => {
     try {
-      const code = getDigiPin(parseFloat(latitude), parseFloat(longitude));
-      res.json({ digipin: code });
+      const digipin = getDigiPin(latitude, longitude);
+      return { latitude, longitude, digipin };
     } catch (e) {
-      res.status(400).json({ error: e.message });
+      return { latitude, longitude, error: e.message };
     }
   });
-  
-  router.get('/decode', (req, res) => {
-    const { digipin } = req.query;
+
+  res.json({ results });
+});
+
+// POST /decode/batch
+router.post("/decode/batch", (req, res) => {
+  const { digipins } = req.body;
+
+  if (!Array.isArray(digipins)) {
+    return res.status(400).json({ error: "digipins must be an array" });
+  }
+
+  if (digipins.length > MAX_BATCH_SIZE) {
+    return res
+      .status(413)
+      .json({ error: `Max ${MAX_BATCH_SIZE} digipins allowed` });
+  }
+
+  const results = digipins.map((digipin) => {
     try {
-      const coords = getLatLngFromDigiPin(digipin);
-      res.json(coords);
+      const { latitude, longitude } = getLatLngFromDigiPin(digipin);
+      return { digipin, latitude, longitude };
     } catch (e) {
-      res.status(400).json({ error: e.message });
+      return { digipin, error: e.message };
     }
   });
 
-  
+  res.json({ results });
+});
+
 module.exports = router;

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -107,3 +107,97 @@ paths:
                     type: number
         '400':
           description: Invalid DIGIPIN
+
+  /digipin/encode/batch:
+    post:
+      summary: Encode multiple coordinates into DIGIPINs
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - coords
+              properties:
+                coords:
+                  type: array
+                  description: List of latitude and longitude objects
+                  items:
+                    type: object
+                    required:
+                      - latitude
+                      - longitude
+                    properties:
+                      latitude:
+                        type: number
+                      longitude:
+                        type: number
+      responses:
+        '200':
+          description: Encoded DIGIPINs for each coordinate
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        latitude:
+                          type: number
+                        longitude:
+                          type: number
+                        digipin:
+                          type: string
+                        error:
+                          type: string
+        '400':
+          description: Invalid request format
+        '413':
+          description: Too many items in batch
+
+  /digipin/decode/batch:
+    post:
+      summary: Decode multiple DIGIPINs into coordinates
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - digipins
+              properties:
+                digipins:
+                  type: array
+                  description: List of DIGIPIN strings
+                  items:
+                    type: string
+      responses:
+        '200':
+          description: Decoded coordinates for each DIGIPIN
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        digipin:
+                          type: string
+                        latitude:
+                          type: string
+                        longitude:
+                          type: string
+                        error:
+                          type: string
+        '400':
+          description: Invalid request format
+        '413':
+          description: Too many items in batch


### PR DESCRIPTION
### Summary
Added two new endpoints:
- `POST /digipin/encode/batch`: Encode multiple coordinates into DIGIPINs
- `POST /digipin/decode/batch`: Decode multiple DIGIPINs into lat/lon

### Features
- Input validation and per-item error handling
- 413 error for exceeding batch size
- Consistent response schema with `error` field
- Swagger/OpenAPI updated

### Motivation
This adds batch support for bulk address resolution, making the API more scalable and efficient for larger datasets.

Let me know if any changes or improvements are needed.
