### PR TITLE
Proposal: Support for Standard Country Codes and Variable Code Lengths (as per country preference) in DIGIPIN 

### DIFF
--- a/src/digipin.js
+++ b/src/digipin.js
@@ -4,9 +4,22 @@
  * Released under an open-source license for public use
  *
  * This module contains two main functions:
- *  - getDigiPin(lat, lon): Encodes latitude & longitude into a 10-digit alphanumeric DIGIPIN
- *  - getLatLngFromDigiPin(digiPin): Decodes a DIGIPIN back into its central latitude & longitude
+ * - getDigiPin(lat, lon, countryCode):
+ *    Generates a DIGIPIN, which is an alphanumeric code of country-specific length,
+ *    by encoding the provided latitude and longitude.
+ * 
+ * - getLatLngFromDigiPin(digiPin, countryCode): Decodes a DIGIPIN back into its central latitude & longitude as per specified country code
  */
+
+const BOUNDS = {
+    "IN":{
+    length: 10,
+    minLat: 2.5,
+    maxLat: 38.5,
+    minLon: 63.5,
+    maxLon: 99.5
+  }
+};
 
 const DIGIPIN_GRID = [
     ['F', 'C', '9', '8'],
@@ -15,25 +28,20 @@ const DIGIPIN_GRID = [
     ['L', 'M', 'P', 'T']
   ];
   
-  const BOUNDS = {
-    minLat: 2.5,
-    maxLat: 38.5,
-    minLon: 63.5,
-    maxLon: 99.5
-  };
+
+  function getDigiPin(lat, lon, countryCode) {
+    if (!BOUNDS[countryCode]) throw new Error('Unsupported country code');
+    if (lat < BOUNDS[countryCode].minLat || lat > BOUNDS[countryCode].maxLat) throw new Error('Latitude out of range');
+    if (lon < BOUNDS[countryCode].minLon || lon > BOUNDS[countryCode].maxLon) throw new Error('Longitude out of range');
   
-  function getDigiPin(lat, lon) {
-    if (lat < BOUNDS.minLat || lat > BOUNDS.maxLat) throw new Error('Latitude out of range');
-    if (lon < BOUNDS.minLon || lon > BOUNDS.maxLon) throw new Error('Longitude out of range');
-  
-    let minLat = BOUNDS.minLat;
-    let maxLat = BOUNDS.maxLat;
-    let minLon = BOUNDS.minLon;
-    let maxLon = BOUNDS.maxLon;
+    let minLat = BOUNDS[countryCode].minLat;
+    let maxLat = BOUNDS[countryCode].maxLat;
+    let minLon = BOUNDS[countryCode].minLon;
+    let maxLon = BOUNDS[countryCode].maxLon;
   
     let digiPin = '';
-  
-    for (let level = 1; level <= 10; level++) {
+    
+    for (let level = 1; level <= BOUNDS[countryCode].length; level++) {
       const latDiv = (maxLat - minLat) / 4;
       const lonDiv = (maxLon - minLon) / 4;
   
@@ -58,18 +66,19 @@ const DIGIPIN_GRID = [
   
     return digiPin;
   }
-  
-  
-  function getLatLngFromDigiPin(digiPin) {
+
+
+  function getLatLngFromDigiPin(digiPin, countryCode) {
     const pin = digiPin.replace(/-/g, '');
-    if (pin.length !== 10) throw new Error('Invalid DIGIPIN');
+    if (!BOUNDS[countryCode]) throw new Error('Unsupported country code');
+    if (pin.length !== BOUNDS[countryCode].length) throw new Error('Invalid DIGIPIN');
     
-    let minLat = BOUNDS.minLat;
-    let maxLat = BOUNDS.maxLat;
-    let minLon = BOUNDS.minLon;
-    let maxLon = BOUNDS.maxLon;
+    let minLat = BOUNDS[countryCode].minLat;
+    let maxLat = BOUNDS[countryCode].maxLat;
+    let minLon = BOUNDS[countryCode].minLon;
+    let maxLon = BOUNDS[countryCode].maxLon;
   
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < BOUNDS[countryCode].length; i++) {
       const char = pin[i];
       let found = false;
       let ri = -1, ci = -1;

--- a/src/routes/digipin.routes.js
+++ b/src/routes/digipin.routes.js
@@ -2,29 +2,29 @@ const express = require('express');
 const router = express.Router();
 const { getDigiPin, getLatLngFromDigiPin } = require('../digipin');
 
-router.post('/encode', (req, res) => { const { latitude, longitude } = req.body; try { const code = getDigiPin(latitude, longitude); res.json({ digipin: code }); } catch (e) { res.status(400).json({ error: e.message }); } });
+router.post('/encode', (req, res) => { const { latitude, longitude, countryCode } = req.body; try { const code = getDigiPin(latitude, longitude, countryCode); res.json({ digipin: code }); } catch (e) { res.status(400).json({ error: e.message }); } });
 
-router.post('/decode', (req, res) => { const { digipin } = req.body; try { const coords = getLatLngFromDigiPin(digipin); res.json(coords); } catch (e) { res.status(400).json({ error: e.message }); } });
+router.post('/decode', (req, res) => { const { digipin, countryCode } = req.body; try { const coords = getLatLngFromDigiPin(digipin, countryCode); res.json(coords); } catch (e) { res.status(400).json({ error: e.message }); } });
 
-  router.get('/encode', (req, res) => {
-    const { latitude, longitude } = req.query;
-    try {
-      const code = getDigiPin(parseFloat(latitude), parseFloat(longitude));
-      res.json({ digipin: code });
-    } catch (e) {
-      res.status(400).json({ error: e.message });
-    }
-  });
+router.get('/encode', (req, res) => {
+  const { latitude, longitude, countryCode } = req.query;
+  try {
+    const code = getDigiPin(parseFloat(latitude), parseFloat(longitude), countryCode );
+    res.json({ digipin: code });
+  } catch (e) {
+    res.status(400).json({ error: e.message });
+  }
+});
   
-  router.get('/decode', (req, res) => {
-    const { digipin } = req.query;
-    try {
-      const coords = getLatLngFromDigiPin(digipin);
-      res.json(coords);
-    } catch (e) {
-      res.status(400).json({ error: e.message });
-    }
-  });
+router.get('/decode', (req, res) => {
+  const { digipin, countryCode } = req.query;
+  try {
+    const coords = getLatLngFromDigiPin(digipin, countryCode);
+    res.json(coords);
+  } catch (e) {
+    res.status(400).json({ error: e.message });
+  }
+});
 
   
 module.exports = router;


### PR DESCRIPTION
### Summary
DIGIPIN’s current design uses a fixed 10-character alphanumeric grid anchored to India’s bounding box. 
To enable global adoption and accommodate varying geospatial precision requirements, the proposal is:

- Incorporating ISO 3166-1 alpha-2 country codes as a fixed prefix or namespace.

- Allowing variable DIGIPIN lengths based on each country’s geodetic accuracy and service needs.

### Motivation

- Precision Tailoring: Countries with high-precision GNSS infrastructure (e.g., urbanized nations) may require finer grid cells (e.g., 3 m×3 m), whereas others may only need coarser resolution (e.g., 10 m×10 m) to balance complexity and database size.

- Backward Compatibility: Country specific length of DIGIPIN enables longer or shorter codes elsewhere.

### Detailed Design

- Added country specific bounding box and DIGIPIN length 
- Implemented dynamic approach on the code logic
- Enabled country code in API parameters (for India, country code is taken as IN)
- Handled error for invalid country codes (At present, only India is configured)
