### PR TITLE
swagger had fixed port 5000.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -10,6 +10,14 @@ const path = require('path');
 // const swaggerDocument = YAML.load(path.join(__dirname, '../swagger.yaml'));
 const swaggerDocument = YAML.parse(fs.readFileSync(path.join(__dirname, '../swagger.yaml'), 'utf8'));
 
+// Make port configurable in swagger document
+const PORT = process.env.PORT || 5000;
+swaggerDocument.servers = [
+  {
+    url: `http://localhost:${PORT}/api`
+  }
+];
+
 const app = express();
 
 // Middleware

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4,6 +4,7 @@ info:
   description: Encode and decode DIGIPIN based on latitude and longitude
   version: 1.0.0
 servers:
+  # Server URL is dynamically configured in app.js based on process.env.PORT
   - url: http://localhost:5000/api
 
 paths:


### PR DESCRIPTION
swagger had fixed port 5000, if different port is used in env variables, it will not work. fixed it. 